### PR TITLE
Check readyState so we run even when load has already fired

### DIFF
--- a/gravatar-zoom.user.js
+++ b/gravatar-zoom.user.js
@@ -21,8 +21,13 @@ var PREFIXES    = ['', '-webkit-', '-moz-', '-o-', '-ms-']
                   /opera/i.test(UA) ? 'oTransitionEnd' : 'transitionend' // Fx
   ;
 
-// we want a guarantee that all gravatars are loaded before we peek at them
-$(window).load(init);
+// We want a guarantee that all gravatars are loaded before we peek at them,
+// and that we do actually run if the `load` event has already fired.
+if (document.readyState == "complete") {
+  init();
+} else {
+  $(window).load(init);
+}
 
 function prefix_rule(rule) {
   return PREFIXES.map(function(browser) { return browser + rule; }).join('');


### PR DESCRIPTION
Well, I guess when it's in GM/Chrome userscript form, and injected as specified at `document-end`, this doesn't matter. But if the code is actually run after the `load` event has fired, then `$(window).load(init)` will never run `init()`.
